### PR TITLE
[DEPRECATION WARNING]: evaluating miniconda_pkg_update as a bare

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
 - name: update base miniconda packages
   command: bash -lc "conda update -y --all"
   register: upd
-  when: miniconda_pkg_update
+  when: miniconda_pkg_update|bool
   # yamllint disable-line rule:line-length
   changed_when: upd.stdout is not search('All requested packages already installed')
   failed_when: upd.rc != 0


### PR DESCRIPTION
variable, this behaviour will go away and you might need to add |bool to
the expression in the future. Also see CONDITIONAL_BARE_VARS
configuration toggle.. This feature will be removed in version 2.12.
Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.